### PR TITLE
chore(deps): remove unused dependency pillow

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ sphinx = "^5.2.3"
 sphinxcontrib-bibtex = "^2.5.0"
 sphinx-gallery = "^0.11.1"
 pydata-sphinx-theme = "^0.11.0"
-pillow = "^9.2.0"
+pillow = "^10.0.0"
 matplotlib = "^3.6.0"
 
 [tool.poetry-dynamic-versioning]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,6 @@ sphinx = "^5.2.3"
 sphinxcontrib-bibtex = "^2.5.0"
 sphinx-gallery = "^0.11.1"
 pydata-sphinx-theme = "^0.11.0"
-pillow = "^10.0.0"
 matplotlib = "^3.6.0"
 
 [tool.poetry-dynamic-versioning]


### PR DESCRIPTION
Pillow is a dependency for matplotlib and sphinx-gallery; removing as a project dependency lets poetry manage the version. 