### PR TITLE
fix(docs): fix zero linerate in docs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.8
+          python-version: 3.12
       - name: install poetry
         run: |
           python -m pip install --upgrade pip wheel pipx
@@ -63,7 +63,7 @@ jobs:
       - name: Install Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.8
+          python-version: 3.12
       - name: install poetry
         run: |
           python -m pip install --upgrade pip wheel pipx

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python: ['3.9', '3.10', '3.11']
+        python: ['3.9', '3.10', '3.11', '3.12']
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/examples/plot_cigre.py
+++ b/examples/plot_cigre.py
@@ -74,7 +74,7 @@ model = linerate.Cigre601(span, weather, time_of_measurement)
 # Compute line rating and temperature
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-max_conductor_temperature = np.linspace(0, 100, 101)
+max_conductor_temperature = np.linspace(26, 100, 75)
 current_load = np.linspace(0, 1_000, 101)
 
 conductor_rating = model.compute_steady_state_ampacity(max_conductor_temperature)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "linerate"
-version = "1.0.0"
+version = "1.0.1"
 description = "Library for computing line ampacity ratings for overhead lines"
 authors = ["Statnett Datascience <Datascience.Drift@Statnett.no>", "Yngve Mardal Moe <yngve.m.moe@gmail.com>"]
 repository = "https://github.com/statnett/linerate.git"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ repository = "https://github.com/statnett/linerate.git"
 readme = "README.md"
 
 [tool.poetry.dependencies]
-python = ">=3.9,<4.0"
+python = ">=3.9,<3.13"
 numpy = "*"
 scipy = "*"
 numba = ">=0.56.4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "linerate"
-version = "1.0.1"
+version = "1.0.0"
 description = "Library for computing line ampacity ratings for overhead lines"
 authors = ["Statnett Datascience <Datascience.Drift@Statnett.no>", "Yngve Mardal Moe <yngve.m.moe@gmail.com>"]
 repository = "https://github.com/statnett/linerate.git"


### PR DESCRIPTION
* fix zero-linerate in example used in docs. Required to generate docs without exceptions

* update test and deploy pipelines to include and use latest python (v3.12)