### PR TITLE
Correct hour angle for longitude

### DIFF
--- a/docs/api/equations/solar_angles.rst
+++ b/docs/api/equations/solar_angles.rst
@@ -1,0 +1,5 @@
+Solar angles
+-------------
+
+.. automodule:: linerate.equations.solar_angles
+    :members:

--- a/examples/plot_solar_heating_comparison.py
+++ b/examples/plot_solar_heating_comparison.py
@@ -21,7 +21,7 @@ from linerate.equations.math import switch_cos_sin
 # ^^^^^^^^^^^^^^^^^^^^^
 time = np.datetime64("2022-06-01T13:00")
 
-omega = solar_angles.compute_hour_angle_relative_to_noon(time)
+omega = solar_angles.compute_hour_angle_relative_to_noon(time, 0)
 delta = solar_angles.compute_solar_declination(time)
 
 vals_with_range = {

--- a/linerate/model.py
+++ b/linerate/model.py
@@ -339,7 +339,7 @@ class Cigre601(ThermalModel):
         N_s = self.weather.clearness_ratio
         D = self.span.conductor.conductor_diameter
 
-        omega = solar_angles.compute_hour_angle_relative_to_noon(self.time)
+        omega = solar_angles.compute_hour_angle_relative_to_noon(self.time, self.span.longitude)
         delta = solar_angles.compute_solar_declination(self.time)
         sin_H_s = solar_angles.compute_sin_solar_altitude(phi, delta, omega)
         chi = solar_angles.compute_solar_azimuth_variable(phi, delta, omega)
@@ -491,7 +491,7 @@ class IEEE738(ThermalModel):
         y = self.span.conductor_altitude  # H_e in IEEE
         D = self.span.conductor.conductor_diameter  # D_0 in IEEE
 
-        omega = solar_angles.compute_hour_angle_relative_to_noon(self.time)
+        omega = solar_angles.compute_hour_angle_relative_to_noon(self.time, self.span.longitude)
         delta = solar_angles.compute_solar_declination(self.time)
         sin_H_c = solar_angles.compute_sin_solar_altitude(phi, delta, omega)
         Q_s = ieee738.solar_heating.compute_total_heat_flux_density(sin_H_c, True)

--- a/tests/equations/test_solar_angles.py
+++ b/tests/equations/test_solar_angles.py
@@ -41,7 +41,14 @@ def test_get_minute_of_hour_with_example():
 def test_hour_angle_relative_to_noon_with_example():
     when = np.datetime64("2022-06-01T12:00")
     omega = 0
-    assert solar_angles.compute_hour_angle_relative_to_noon(when) == approx(omega)
+    assert solar_angles.compute_hour_angle_relative_to_noon(when, 0) == approx(omega)
+
+
+def test_hour_angle_relative_to_noon_norway():
+    when = np.datetime64("2022-12-01T12:00+01:00")
+    omega = 0
+    longitude = 15  # Longitude at timezone +01:00
+    assert solar_angles.compute_hour_angle_relative_to_noon(when, longitude) == approx(omega)
 
 
 def test_solar_azimuth_variable_with_example():
@@ -119,12 +126,13 @@ def test_solar_declination_scales_correctly_with_day_of_year(day):
     when=st.datetimes(
         min_value=datetime.datetime(2022, 1, 1, 1, 0),
         max_value=datetime.datetime(2022, 12, 31, 23, 0),
-    )
+    ),
+    longitude=st.floats(min_value=-180, max_value=180),
 )
-def test_solar_declination_scales_with_dates_and_times(when):
-    omega = (-12 + when.hour + when.minute / 60) * np.pi / 12
+def test_solar_declination_scales_with_dates_and_times(when, longitude):
+    omega = ((-12 + when.hour + when.minute / 60 + longitude / 15) % 24) * np.pi / 12
     when = np.datetime64(when)
-    assert omega == approx(solar_angles.compute_hour_angle_relative_to_noon(when))
+    assert omega == approx(solar_angles.compute_hour_angle_relative_to_noon(when, longitude))
 
 
 def test_solar_declination_with_examples():


### PR DESCRIPTION
Previously, hour angle was calculated at longitude 0, which was incorrect.