### PR TITLE
Improve bisect nan handling

### DIFF
--- a/linerate/solver.py
+++ b/linerate/solver.py
@@ -61,7 +61,8 @@ def bisect(
     elif isinstance(invalid_mask, bool) and invalid_mask:
         return _invalid_value
 
-    while interval > tolerance:
+    nan_mask = np.full_like(f_left, False, dtype=bool)
+    while interval > tolerance and not np.all(nan_mask):
         xmid = 0.5 * (xmax + xmin)
         interval *= 0.5
         f_mid = f(xmid)
@@ -72,7 +73,10 @@ def bisect(
         f_left = np.where(mask, f_mid, f_left)
         f_right = np.where(mask, f_right, f_mid)
 
+        nan_mask = np.isnan(f_left) | np.isnan(f_right)
+
     out = np.where(invalid_mask, _invalid_value, 0.5 * (xmax + xmin))
+    out = np.where(nan_mask, np.nan, out)
     return out
 
 

--- a/linerate/solver.py
+++ b/linerate/solver.py
@@ -61,7 +61,7 @@ def bisect(
     elif isinstance(invalid_mask, bool) and invalid_mask:
         return _invalid_value
 
-    nan_mask = np.full_like(f_left, False, dtype=bool)
+    nan_mask = np.isnan(f_left) | np.isnan(f_right)
     while interval > tolerance and not np.all(nan_mask):
         xmid = 0.5 * (xmax + xmin)
         interval *= 0.5

--- a/tests/test_solver.py
+++ b/tests/test_solver.py
@@ -87,3 +87,35 @@ def test_bisect_raises_valueerror_when_infinite_in_array_input():
             xmax=np.array([10_000, 10_000]),
             tolerance=1e-8,
         )
+
+
+def test_bisect_returns_dtype_float_if_invalid_value_is_none():
+    def heat_balance(currents: np.array):
+        A = currents
+        T = 90
+        res = (A - 100 * T) * (currents + 100 * T)
+        return res
+
+    solution = solver.bisect(
+        heat_balance,
+        xmin=np.array([0, 0]),
+        xmax=np.array([10_000, 10_000]),
+        tolerance=1e-8,
+        invalid_value=None,
+    )
+
+    assert solution.dtype == np.float64
+
+
+def test_bisect_return_nan_if_heat_balance_returns_nan():
+    def heat_balance(currents: np.array):
+        return np.ones_like(currents) * np.nan
+
+    solution = solver.bisect(
+        heat_balance,
+        xmin=np.array([0, 0]),
+        xmax=np.array([10_000, 10_000]),
+        tolerance=1e-8,
+    )
+
+    np.testing.assert_array_equal(np.isnan(solution), np.full_like(solution, True, dtype=bool))


### PR DESCRIPTION
In ´bisect´, if the function ´f´ returns NaN, ´bisect´ will converge the solution to the average between the inputs ´xmin´ and ´xmax´. This is unfortunate as, if the function ´f´ returns NaN, the solution is not defined.

This PR changes this behavior and ensures that any elements for which ´f´ returns NaN, the solution ´bisect´ returns will also be NaN.