### PR TITLE
Modify bisect to only use np.nan as an invalid value

### DIFF
--- a/linerate/models/thermal_model.py
+++ b/linerate/models/thermal_model.py
@@ -198,6 +198,7 @@ class ThermalModel(ABC):
         min_ampacity: Ampere = 0,
         max_ampacity: Ampere = 5000,
         tolerance: float = 1.0,
+        invalid_value: float | None = None,
     ) -> Ampere:
         r"""Use the bisection method to compute the steady-state thermal rating (ampacity).
 
@@ -216,6 +217,10 @@ class ThermalModel(ABC):
             bisection iterations will stop once the numerical ampacity uncertainty is below
             :math:`\Delta I`. The bisection method will run for
             :math:`\left\lceil\frac{I_\text{min} - I_\text{min}}{\Delta I}\right\rceil` iterations.
+        invalid_value:
+            If the optimization problem is invalid, this value is returned instead of an error.
+            Suggested value: 0 for 0-ampacity when max_conductor_temperature is exceeded for all
+            ampacities.
 
         Returns
         -------
@@ -228,6 +233,7 @@ class ThermalModel(ABC):
             min_ampacity=min_ampacity,
             max_ampacity=max_ampacity,
             tolerance=tolerance,
+            invalid_value=invalid_value,
         )
         n = self.span.num_conductors
         return I * n

--- a/linerate/models/thermal_model.py
+++ b/linerate/models/thermal_model.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Dict, Optional
+from typing import Dict
 
 from linerate import solver
 from linerate.equations import joule_heating, radiative_cooling
@@ -198,7 +198,7 @@ class ThermalModel(ABC):
         min_ampacity: Ampere = 0,
         max_ampacity: Ampere = 5000,
         tolerance: float = 1.0,
-        invalid_value: Optional[float] = None,
+        accept_invalid_values: bool = False,
     ) -> Ampere:
         r"""Use the bisection method to compute the steady-state thermal rating (ampacity).
 
@@ -217,10 +217,9 @@ class ThermalModel(ABC):
             bisection iterations will stop once the numerical ampacity uncertainty is below
             :math:`\Delta I`. The bisection method will run for
             :math:`\left\lceil\frac{I_\text{min} - I_\text{min}}{\Delta I}\right\rceil` iterations.
-        invalid_value:
-            If the optimization problem is invalid, this value is returned instead of an error.
-            Suggested value: 0 for 0-ampacity when max_conductor_temperature is exceeded for all
-            ampacities.
+        accept_invalid_values:
+            If True, np.nan is returned whenever the current cannot be found within the provided
+            search interval. If False, a ValueError will be raised instead.
 
         Returns
         -------
@@ -233,7 +232,7 @@ class ThermalModel(ABC):
             min_ampacity=min_ampacity,
             max_ampacity=max_ampacity,
             tolerance=tolerance,
-            invalid_value=invalid_value,
+            accept_invalid_values=accept_invalid_values,
         )
         n = self.span.num_conductors
         return I * n

--- a/linerate/models/thermal_model.py
+++ b/linerate/models/thermal_model.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Dict
+from typing import Dict, Optional
 
 from linerate import solver
 from linerate.equations import joule_heating, radiative_cooling
@@ -198,7 +198,7 @@ class ThermalModel(ABC):
         min_ampacity: Ampere = 0,
         max_ampacity: Ampere = 5000,
         tolerance: float = 1.0,
-        invalid_value: float | None = None,
+        invalid_value: Optional[float] = None,
     ) -> Ampere:
         r"""Use the bisection method to compute the steady-state thermal rating (ampacity).
 

--- a/linerate/solver.py
+++ b/linerate/solver.py
@@ -125,7 +125,7 @@ def compute_conductor_ampacity(
     min_ampacity: Ampere = 0,
     max_ampacity: Ampere = 5_000,
     tolerance: float = 1,  # Ampere
-    invalid_value=None,
+    invalid_value: float | None = None,
 ) -> Ampere:
     r"""Use the bisection method to compute the steady-state thermal rating (ampacity).
 
@@ -149,7 +149,7 @@ def compute_conductor_ampacity(
         :math:`\Delta I`. The bisection method will run for
         :math:`\left\lceil\frac{I_\text{max} - I_\text{min}}{\Delta I}\right\rceil` iterations.
     invalid_value:
-        if the optimization problem is invalid, this value is returned instead of an error.
+        If the optimization problem is invalid, this value is returned instead of an error.
         Suggested value: 0 for 0-ampacity when max_conductor_temperature is exceeded for all
         ampacities.
 

--- a/linerate/solver.py
+++ b/linerate/solver.py
@@ -125,7 +125,7 @@ def compute_conductor_ampacity(
     min_ampacity: Ampere = 0,
     max_ampacity: Ampere = 5_000,
     tolerance: float = 1,  # Ampere
-    invalid_value: float | None = None,
+    invalid_value: Optional[float] = None,
 ) -> Ampere:
     r"""Use the bisection method to compute the steady-state thermal rating (ampacity).
 

--- a/tests/test_solver.py
+++ b/tests/test_solver.py
@@ -89,7 +89,7 @@ def test_bisect_raises_valueerror_when_infinite_in_array_input():
         )
 
 
-def test_bisect_returns_dtype_float_if_invalid_value_is_none():
+def test_bisect_returns_dtype_float_if_not_accept_invalid_values():
     def heat_balance(currents: np.array):
         A = currents
         T = 90
@@ -101,7 +101,7 @@ def test_bisect_returns_dtype_float_if_invalid_value_is_none():
         xmin=np.array([0, 0]),
         xmax=np.array([10_000, 10_000]),
         tolerance=1e-8,
-        invalid_value=None,
+        accept_invalid_values=False,
     )
 
     assert solution.dtype == np.float64


### PR DESCRIPTION
In certain cases a solution to the ampacity given a thermal model does not exist, e.g. large solar heating combined with low winds and a low maximum conductor temperature, causing the steady state temperature of the conductor to be larger than the maximum conductor temperature even without a current. In such cases the current code may raise a `ValueError` in `bisect`.

The current code allows for setting the `invalid_value` option in `bisect` to avoid this, but it is not exposed in the ampacity calculation and it does not distinguish between when f < 0 or f > 0, which reduces the usability of this feature.

This MR changes `bisect` to only use `np.nan` as the invalid value. The ´invalid_value´ parameter is replaced with an option whether or not invalid values are accepted.