### PR TITLE
TKAP-1340: Ampacity set to 0 when heat balance is positive at 0

### DIFF
--- a/linerate/models/thermal_model.py
+++ b/linerate/models/thermal_model.py
@@ -213,7 +213,7 @@ class ThermalModel(ABC):
         self,
         max_conductor_temperature: Celsius,
         min_ampacity: Ampere = 0,
-        max_ampacity: Ampere = 5000,
+        max_ampacity: Ampere = 8000,
         tolerance: float = 1.0,
         accept_invalid_values: bool = False,
     ) -> Ampere:

--- a/linerate/models/thermal_model.py
+++ b/linerate/models/thermal_model.py
@@ -215,7 +215,6 @@ class ThermalModel(ABC):
         min_ampacity: Ampere = 0,
         max_ampacity: Ampere = 8000,
         tolerance: float = 1.0,
-        accept_invalid_values: bool = False,
     ) -> Ampere:
         r"""Use the bisection method to compute the steady-state thermal rating (ampacity).
 
@@ -234,9 +233,6 @@ class ThermalModel(ABC):
             bisection iterations will stop once the numerical ampacity uncertainty is below
             :math:`\Delta I`. The bisection method will run for
             :math:`\left\lceil\frac{I_\text{min} - I_\text{min}}{\Delta I}\right\rceil` iterations.
-        accept_invalid_values:
-            If True, np.nan is returned whenever the current cannot be found within the provided
-            search interval. If False, a ValueError will be raised instead.
 
         Returns
         -------
@@ -249,7 +245,6 @@ class ThermalModel(ABC):
             min_ampacity=min_ampacity,
             max_ampacity=max_ampacity,
             tolerance=tolerance,
-            accept_invalid_values=accept_invalid_values,
         )
         n = self.span.num_conductors
         return I * n
@@ -376,7 +371,6 @@ class ThermalModel(ABC):
         min_ampacity: Ampere = 0,
         max_ampacity: Ampere = 8000,
         tolerance: float = 1.0,
-        accept_invalid_values: bool = False,
     ):
         r"""Use the bisection method to compute the transient thermal rating (ampacity).
 
@@ -401,10 +395,6 @@ class ThermalModel(ABC):
             bisection iterations will stop once the numerical ampacity uncertainty is below
             :math:`\Delta I`. The bisection method will run for
             :math:`\left\lceil\frac{I_\text{min} - I_\text{min}}{\Delta I}\right\rceil` iterations.
-        accept_invalid_values:
-            If True, np.nan is returned whenever the current cannot be found within the provided
-            search interval. If False, a ValueError will be raised instead.
-
 
         Returns
         -------
@@ -420,6 +410,5 @@ class ThermalModel(ABC):
             min_ampacity,
             max_ampacity,
             tolerance,
-            accept_invalid_values,
         )
         return I * n

--- a/linerate/models/thermal_model.py
+++ b/linerate/models/thermal_model.py
@@ -374,7 +374,7 @@ class ThermalModel(ABC):
         initial_conductor_temperature: Celsius,
         time_step: Duration = np.timedelta64(60, "s"),
         min_ampacity: Ampere = 0,
-        max_ampacity: Ampere = 5000,
+        max_ampacity: Ampere = 8000,
         tolerance: float = 1.0,
         accept_invalid_values: bool = False,
     ):

--- a/linerate/solver.py
+++ b/linerate/solver.py
@@ -130,7 +130,7 @@ def compute_conductor_ampacity(
     heat_balance: Callable[[Celsius, Ampere], WattPerMeter],
     max_conductor_temperature: Celsius,
     min_ampacity: Ampere = 0,
-    max_ampacity: Ampere = 5_000,
+    max_ampacity: Ampere = 8000,
     tolerance: float = 1,  # Ampere
     accept_invalid_values: bool = False,
 ) -> Ampere:
@@ -158,6 +158,7 @@ def compute_conductor_ampacity(
     accept_invalid_values:
         If True, np.nan is returned whenever the current cannot be found within the provided
         search interval. If False, a ValueError will be raised instead.
+        A positive heat balance at 0 A returns an ampacity of 0 A.
 
     Returns
     -------
@@ -165,6 +166,9 @@ def compute_conductor_ampacity(
         :math:`I~\left[\text{A}\right]`. The thermal rating.
     """
     f = partial(heat_balance, max_conductor_temperature)
+
+    if f(0) > 0:
+        return 0
 
     return bisect(
         f, min_ampacity, max_ampacity, tolerance, accept_invalid_values=accept_invalid_values
@@ -177,7 +181,7 @@ def compute_conductor_transient_ampacity(
     initial_conductor_temperature: Celsius,
     heating_duration: Duration,
     min_ampacity: Ampere = 0,
-    max_ampacity: Ampere = 5_000,
+    max_ampacity: Ampere = 8000,
     tolerance: float = 1,  # Ampere
     accept_invalid_values: bool = False,
 ) -> Ampere:

--- a/linerate/solver.py
+++ b/linerate/solver.py
@@ -162,19 +162,7 @@ def compute_conductor_ampacity(
     """
     f = partial(heat_balance, max_conductor_temperature)
     ampacity = bisect(f, min_ampacity, max_ampacity, tolerance, accept_invalid_values=True)
-    if min_ampacity == 0:
-        zero_ampacity_mask = f(0) > 0
-        ampacity = np.where(zero_ampacity_mask, 0, ampacity)
-        invalid_mask = f(max_ampacity) < 0
-    else:
-        invalid_mask = np.sign(f(min_ampacity)) == np.sign(f(max_ampacity))
-
-    if np.any(invalid_mask):
-        raise ValueError(
-            "Ampacity could not be found, consider increasing increasing search interval."
-        )
-
-    return ampacity
+    return _validate_ampacity(f, ampacity, min_ampacity, max_ampacity)
 
 
 def compute_conductor_transient_ampacity(
@@ -185,7 +173,6 @@ def compute_conductor_transient_ampacity(
     min_ampacity: Ampere = 0,
     max_ampacity: Ampere = 8000,
     tolerance: float = 1,  # Ampere
-    accept_invalid_values: bool = False,
 ) -> Ampere:
     r"""Use the bisection method to compute the temporary thermal rating (ampacity).
 
@@ -204,16 +191,13 @@ def compute_conductor_transient_ampacity(
         :math:`I_\text{min}~\left[\text{A}\right]`. Lower bound for the numerical scheme for
         computing the ampacity
     max_ampacity:
-        :math:`I_\text{min}~\left[\text{A}\right]`. Upper bound for the numerical scheme for
+        :math:`I_\text{max}~\left[\text{A}\right]`. Upper bound for the numerical scheme for
         computing the ampacity
     tolerance:
         :math:`\Delta I~\left[\text{A}\right]`. The numerical accuracy of the ampacity. The
         bisection iterations will stop once the numerical ampacity uncertainty is below
         :math:`\Delta I`. The bisection method will run for
         :math:`\left\lceil\frac{I_\text{max} - I_\text{min}}{\Delta I}\right\rceil` iterations.
-    accept_invalid_values:
-        If True, np.nan is returned whenever the current cannot be found within the provided
-        search interval. If False, a ValueError will be raised instead.
 
     Returns
     -------
@@ -222,16 +206,23 @@ def compute_conductor_transient_ampacity(
     """
 
     def temperature_difference(current: Ampere) -> Celsius:
-        return max_conductor_temperature - final_temperature(
-            initial_conductor_temperature, heating_duration, current
+        return (
+            final_temperature(initial_conductor_temperature, heating_duration, current)
+            - max_conductor_temperature
         )
 
-    return bisect(
+    ampacity = bisect(
         temperature_difference,
         min_ampacity,
         max_ampacity,
         tolerance,
-        accept_invalid_values=accept_invalid_values,
+        accept_invalid_values=True,
+    )
+    return _validate_ampacity(
+        temperature_difference,
+        ampacity,
+        min_ampacity,
+        max_ampacity,
     )
 
 
@@ -269,3 +260,41 @@ def solve_ivp_forward_euler(
     if remainder > 0:
         y = y + f(y) * remainder
     return y
+
+
+def _validate_ampacity(
+    f: Callable[[FloatOrFloatArray], FloatOrFloatArray],
+    ampacity: Ampere,
+    min_ampacity: Ampere,
+    max_ampacity: Ampere,
+) -> Ampere:
+    r"""If min_ampacity is 0, the ampacity is set to zero if the heat balance is positive at zero current.
+    Any ampacity that is outside the search interval is considered invalid and will raise a ValueError.
+
+    Parameters
+    ----------
+    f:
+        :math:`f: \mathbb{R}^n \to \mathbb{R}^n`. Heat/temperature balance function whose roots give the ampacity.
+    ampacity:
+        :math:`I~\left[\text{A}\right]`. The thermal rating.
+    min_ampacity:
+        :math:`I_\text{min}~\left[\text{A}\right]`. Lower bound for the numerical scheme for computing the ampacity
+    max_ampacity:
+        :math:`I_\text{max}~\left[\text{A}\right]`. Upper bound for the numerical scheme for computing the ampacity
+
+    Returns
+    -------
+    Union[float, float64, ndarray[Any, dtype[float64]]]
+        :math:`I~\left[\text{A}\right]`. The validated rating.
+    """
+    if min_ampacity == 0:
+        zero_ampacity_mask = f(0) > 0
+        ampacity = np.where(zero_ampacity_mask, 0, ampacity)
+        invalid_mask = f(max_ampacity) < 0
+    else:
+        invalid_mask = np.sign(f(min_ampacity)) == np.sign(f(max_ampacity))
+
+    if np.any(invalid_mask):
+        raise ValueError("Ampacity could not be found, consider increasing the search interval.")
+
+    return ampacity

--- a/linerate/solver.py
+++ b/linerate/solver.py
@@ -158,7 +158,7 @@ def compute_conductor_ampacity(
     accept_invalid_values:
         If True, np.nan is returned whenever the current cannot be found within the provided
         search interval. If False, a ValueError will be raised instead.
-        A positive heat balance at 0 A returns an ampacity of 0 A.
+        A positive heat balance at 0 A returns an ampacity of 0 A for the corresponding element.
 
     Returns
     -------
@@ -166,13 +166,18 @@ def compute_conductor_ampacity(
         :math:`I~\left[\text{A}\right]`. The thermal rating.
     """
     f = partial(heat_balance, max_conductor_temperature)
+    ampacity = bisect(f, min_ampacity, max_ampacity, tolerance, accept_invalid_values=True)
+    invalid_mask = np.sign(f(min_ampacity)) == np.sign(f(max_ampacity))
+    zero_ampacity_mask = invalid_mask & (f(0) > 0)
+    ampacity = np.where(zero_ampacity_mask, 0, ampacity)
 
-    if f(0) > 0:
-        return 0
+    if np.any(invalid_mask & ~zero_ampacity_mask) and not accept_invalid_values:
+        raise ValueError(
+            "f(min_ampacity) and f(max_ampacity) have the same sign. "
+            "Consider increasing the search interval."
+        )
 
-    return bisect(
-        f, min_ampacity, max_ampacity, tolerance, accept_invalid_values=accept_invalid_values
-    )
+    return ampacity
 
 
 def compute_conductor_transient_ampacity(

--- a/linerate/solver.py
+++ b/linerate/solver.py
@@ -147,7 +147,7 @@ def compute_conductor_ampacity(
         :math:`I_\text{min}~\left[\text{A}\right]`. Lower bound for the numerical scheme for
         computing the ampacity
     max_ampacity:
-        :math:`I_\text{min}~\left[\text{A}\right]`. Upper bound for the numerical scheme for
+        :math:`I_\text{max}~\left[\text{A}\right]`. Upper bound for the numerical scheme for
         computing the ampacity
     tolerance:
         :math:`\Delta I~\left[\text{A}\right]`. The numerical accuracy of the ampacity. The

--- a/linerate/solver.py
+++ b/linerate/solver.py
@@ -132,7 +132,6 @@ def compute_conductor_ampacity(
     min_ampacity: Ampere = 0,
     max_ampacity: Ampere = 8000,
     tolerance: float = 1,  # Ampere
-    accept_invalid_values: bool = False,
 ) -> Ampere:
     r"""Use the bisection method to compute the steady-state thermal rating (ampacity).
 
@@ -155,10 +154,6 @@ def compute_conductor_ampacity(
         bisection iterations will stop once the numerical ampacity uncertainty is below
         :math:`\Delta I`. The bisection method will run for
         :math:`\left\lceil\frac{I_\text{max} - I_\text{min}}{\Delta I}\right\rceil` iterations.
-    accept_invalid_values:
-        If True, np.nan is returned whenever the current cannot be found within the provided
-        search interval. If False, a ValueError will be raised instead.
-        A positive heat balance at 0 A returns an ampacity of 0 A for the corresponding element.
 
     Returns
     -------
@@ -167,14 +162,16 @@ def compute_conductor_ampacity(
     """
     f = partial(heat_balance, max_conductor_temperature)
     ampacity = bisect(f, min_ampacity, max_ampacity, tolerance, accept_invalid_values=True)
-    invalid_mask = np.sign(f(min_ampacity)) == np.sign(f(max_ampacity))
-    zero_ampacity_mask = invalid_mask & (f(0) > 0)
-    ampacity = np.where(zero_ampacity_mask, 0, ampacity)
+    if min_ampacity == 0:
+        zero_ampacity_mask = f(0) > 0
+        ampacity = np.where(zero_ampacity_mask, 0, ampacity)
+        invalid_mask = f(max_ampacity) < 0
+    else:
+        invalid_mask = np.sign(f(min_ampacity)) == np.sign(f(max_ampacity))
 
-    if np.any(invalid_mask & ~zero_ampacity_mask) and not accept_invalid_values:
+    if np.any(invalid_mask):
         raise ValueError(
-            "f(min_ampacity) and f(max_ampacity) have the same sign. "
-            "Consider increasing the search interval."
+            "Ampacity could not be found, consider increasing increasing search interval."
         )
 
     return ampacity

--- a/tests/test_solver.py
+++ b/tests/test_solver.py
@@ -51,6 +51,16 @@ def test_compute_conductor_ampacity_raises_when_solution_exceeds_max_ampacity():
         )
 
 
+def test_compute_conductor_temperature_raises_when_solution_is_below_min_ampacity():
+    def heat_balance(conductor_temperature: Celsius, current: Ampere) -> WattPerMeter:
+        return current**2 - 100
+
+    with pytest.raises(ValueError):
+        solver.compute_conductor_ampacity(
+            heat_balance, max_conductor_temperature=90, min_ampacity=15
+        )
+
+
 def test_bisect_raises_value_error():
     def heat_balance(current):
         I = current  # noqa: E741

--- a/tests/test_solver.py
+++ b/tests/test_solver.py
@@ -30,13 +30,17 @@ def test_compute_conductor_ampacity_computes_correct_ampacity(
     assert conductor_temperature == pytest.approx(9000, rel=1e-7)
 
 
-def test_compute_conductor_ampacity_returns_zero_when_heat_balance_is_positive_at_zero_current():
+def test_compute_conductor_ampacity_returns_zero_for_elements_with_positive_heat_balance_at_zero_current():
     def heat_balance(conductor_temperature: Celsius, current: Ampere) -> WattPerMeter:
-        return current**2 + 1
+        return current**2 - np.array([100, -1, 100])
 
-    ampacity = solver.compute_conductor_ampacity(heat_balance, max_conductor_temperature=90)
+    ampacity = solver.compute_conductor_ampacity(
+        heat_balance, max_conductor_temperature=90, tolerance=1e-8
+    )
 
-    assert ampacity == 0
+    np.testing.assert_array_almost_equal(ampacity, [10, 0, 10], decimal=8)
+
+
 
 
 def test_compute_conductor_ampacity_raises_when_solution_exceeds_max_ampacity():

--- a/tests/test_solver.py
+++ b/tests/test_solver.py
@@ -41,8 +41,6 @@ def test_compute_conductor_ampacity_returns_zero_for_elements_with_positive_heat
     np.testing.assert_array_almost_equal(ampacity, [10, 0, 10], decimal=8)
 
 
-
-
 def test_compute_conductor_ampacity_raises_when_solution_exceeds_max_ampacity():
     def heat_balance(conductor_temperature: Celsius, current: Ampere) -> WattPerMeter:
         return current**2 - 100

--- a/tests/test_solver.py
+++ b/tests/test_solver.py
@@ -30,6 +30,25 @@ def test_compute_conductor_ampacity_computes_correct_ampacity(
     assert conductor_temperature == pytest.approx(9000, rel=1e-7)
 
 
+def test_compute_conductor_ampacity_returns_zero_when_heat_balance_is_positive_at_zero_current():
+    def heat_balance(conductor_temperature: Celsius, current: Ampere) -> WattPerMeter:
+        return current**2 + 1
+
+    ampacity = solver.compute_conductor_ampacity(heat_balance, max_conductor_temperature=90)
+
+    assert ampacity == 0
+
+
+def test_compute_conductor_ampacity_raises_when_solution_exceeds_max_ampacity():
+    def heat_balance(conductor_temperature: Celsius, current: Ampere) -> WattPerMeter:
+        return current**2 - 100
+
+    with pytest.raises(ValueError):
+        solver.compute_conductor_ampacity(
+            heat_balance, max_conductor_temperature=90, max_ampacity=5
+        )
+
+
 def test_bisect_raises_value_error():
     def heat_balance(current):
         I = current  # noqa: E741


### PR DESCRIPTION
- When computing the conductor ampacity, instead of getting an error if the heat balance is positive at current = 0 A, the ampacity is then set to 0 A.
- If the solution is above `max_ampacity`, then an exceptioin is still thrown
- The default `max_ampacity` has been increased to 8000 instead of 5000